### PR TITLE
Moves datetime into properties of JSON output; adds version number.

### DIFF
--- a/controllers/BaseController.php
+++ b/controllers/BaseController.php
@@ -24,7 +24,7 @@ class BaseController extends Controller {
 		'crime_message/map' => 'crime-message/map',
 		'crime_message/crimes' => 'crime-message/crimes',
 	];
-	
+
 	private $modelName;
 	private $doAction;
 

--- a/views/base/api.php
+++ b/views/base/api.php
@@ -30,9 +30,14 @@ use yii\web\Response;
             } else {
                 echo ',';
             }
+            $properties = $model->properties;
             if(isset($model->datetime)){
-                $model->datetime = $model->datetime->toDateTime()->format('c');
+                $properties['datetime'] = $model->datetime->toDateTime()->format('c');
+                unset($model->datetime);
             }
+
+            $properties['version'] = 2;
+            $model->properties = $properties;
             echo json_encode(ArrayHelper::toArray($model), $pretty ? JSON_PRETTY_PRINT : 0);
         }
         echo '], "count" : ' . $count . '}';


### PR DESCRIPTION
This PR changes the JSON output to:

``` json
{
  "type": "FeatureCollection",
  "features": [
    {
      "id": "Cary_17-00001524",
      "properties": {
        "title": "New Permit HERE->http://trg.pw/ZgSfJ Mon Aug 22 Permit type Finish Attic - Rec Room And Full Bath at address 4010 Greyhawk Pl project cost $29900",
        "datetime": "2016-08-22T00:00:00+00:00",
        "version": 2
      },
      "geometry": {
        "type": "Point",
        "coordinates": [
          -78.781512,
          35.704742
        ]
      },
      "type": "Feature"
    },
    ...
    ...
```

This makes the output still compatible with the geojson spec (arbitrary extra vars go in properties), and will let citygram keep better handle the different API versions it'll receive.
